### PR TITLE
match GitHub graph label alignment

### DIFF
--- a/assets/js/gh.js
+++ b/assets/js/gh.js
@@ -25,7 +25,7 @@ function init_table() {
 };
 
 function addMonths(thead, months) {
-    for (let i = 0; i < months.length; i++) {
+    for (let i = 0; i < months.length - 1; i++) {
         const total_weeks = months[i]["totalWeeks"];
         if (total_weeks => 2) {
             let cell = thead.rows[0].insertCell();


### PR DESCRIPTION
<img width="888" alt="Screenshot 2024-04-09 at 1 38 02 AM" src="https://github.com/lengthylyova/gh-contrib-graph/assets/69072/ff849549-ea4a-417a-aef4-c4c43bbf8ef9">

_screenshot from my github profile, without current month at the end._

I saw that Apr for the last label on my implementation only said Ap

css cut off the rest of the label.